### PR TITLE
Clearing ActiveEffect5e#label deprecation warnings

### DIFF
--- a/scripts/modules/Regeneration.js
+++ b/scripts/modules/Regeneration.js
@@ -71,11 +71,11 @@ export class Regeneration {
 
         /** before we check anything else, is regen blocked on this actor? */
         const regenBlockName = HELPER.setting(MODULE.data.name, "regenBlock");
-        const blockEffect = actor.effects?.find(e => e.label === regenBlockName );
+        const blockEffect = actor.effects?.find(e => e.name ?? e.label === regenBlockName );
         const enabledBlockEffect = !(getProperty(blockEffect ?? {}, 'disabled') ?? true);
 
         if (enabledBlockEffect) {
-            logger.debug(game.settings.get(MODULE.data.name, "debug"), `${NAME} | ${actor.name}'s regeneration blocked by ${blockEffect.label}`);
+            logger.debug(game.settings.get(MODULE.data.name, "debug"), `${NAME} | ${actor.name}'s regeneration blocked by ${blockEffect.name ?? blockEffect.label}`);
             return null;
         }
 


### PR DESCRIPTION
With 2.4.0 dnd5e, some deprecation warnings which were previously not shown, are now uncovered.
This gets rid of some triggered by the `Regeneration.js` use of `effect.label`